### PR TITLE
Move Codecov to after mvn tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,12 @@ script:
     - mvn -U -B -V test --fail-at-end -Dsource.skip=true -Dmaven.javadoc.skip=true -pl !:hamcrest-extensions-jdk8
 
 after_success:
-  - codecov
   - jdk_switcher use oraclejdk8
   - mvn clean test jacoco:report coveralls:report
+  - codecov -b "$TRAVIS_JOB_NUMBER-jdk8"
   - jdk_switcher use oraclejdk7
   - mvn clean test jacoco:report coveralls:report -pl !:hamcrest-extensions-jdk8
+  - codecov -b "$TRAVIS_JOB_NUMBER-jdk7"
   
 notifications:
     email:


### PR DESCRIPTION
Codecov could not find reports because they were not generated yet.

I also added:
1. The command twice because `nvm clean` will remove reports.
2. The build argument will help distinguish the builds in Codecov UI, but also properly combine them.

Thank you!
